### PR TITLE
strict field regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Breaking changes
 
+- only parse strings with single colons as fields
+
 ### Compatible changes
 
 

--- a/lib/minidusen/parser.rb
+++ b/lib/minidusen/parser.rb
@@ -4,7 +4,7 @@ module Minidusen
     class CannotParse < StandardError; end
 
     TEXT_QUERY = /(?:(\-)?"([^"]+)"|(\-)?([\S]+))/
-    FIELD_QUERY = /(?:\s|^|(\-))(\w+)\:#{TEXT_QUERY}/
+    FIELD_QUERY = /(?:\s|^|(\-))(\w+):(?!:)#{TEXT_QUERY}/
 
     class << self
 

--- a/lib/minidusen/parser.rb
+++ b/lib/minidusen/parser.rb
@@ -3,8 +3,8 @@ module Minidusen
 
     class CannotParse < StandardError; end
 
-    TEXT_QUERY = /(?:(\-)?"([^"]+)"|(\-)?([\S]+))/
-    FIELD_QUERY = /(?:\s|^|(\-))(\w+):(?!:)#{TEXT_QUERY}/
+    TEXT_QUERY = /(?:(-)?"([^"]+)"|(-)?(\S+))/
+    FIELD_QUERY = /(?:\s|^|(-))(\w+):(?!:)#{TEXT_QUERY}/
 
     class << self
 

--- a/spec/minidusen/parser_spec.rb
+++ b/spec/minidusen/parser_spec.rb
@@ -63,6 +63,15 @@ describe Minidusen::Parser do
         query[0].exclude.should == true
       end
 
+      it 'only parses single colons as fields' do
+        query = Minidusen::Parser.parse('filetype:docx Namespaced::Klass')
+        expect(query.size).to eq(2)
+        expect(query[0].field).to eq('filetype')
+        expect(query[0].value).to eq('docx')
+        expect(query[1].field).to eq('text')
+        expect(query[1].value).to eq('Namespaced::Klass')
+      end
+
       it 'should ignore invalid utf-8 byte sequences' do
         term_with_invalid_byte_sequence = "word\255".force_encoding('UTF-8')
 


### PR DESCRIPTION
In makandracards we noticed that searching for a namespaced class leads to empty results, e.g. `ActiveRecord::Base` https://makandracards.com/makandra/search?query=ActiveRecord%3A%3ABase

This is caused by minidusen parsing it as a field (field `ActiveRecord`, value `:Base`). The more natural thing would be to parse it as text.
I suggest to use a more strict field regex here.