### PR TITLE
Support filter aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,36 @@ ContactFilter.new.filter(Contact, 'email:foo@bar.com').to_sql
 # => "SELECT * FROM contacts WHERE email='foo@bar.com'"
 ```
 
+Filter aliases
+--------------
+
+You can define aliases for the same filter by passing multiple field names to a single `filter` call:
+
+```ruby
+class ContactFilter
+  include Minidusen::Filter
+
+  filter :email, :mail, :contact do |scope, email|
+    scope.where(email: email)
+  end
+end
+```
+
+Now you can search using any of the defined aliases:
+
+```ruby
+ContactFilter.new.filter(Contact, 'email:foo@bar.com').to_sql
+# => "SELECT * FROM contacts WHERE email='foo@bar.com'"
+
+ContactFilter.new.filter(Contact, 'mail:foo@bar.com').to_sql
+# => "SELECT * FROM contacts WHERE email='foo@bar.com'"
+
+ContactFilter.new.filter(Contact, 'contact:foo@bar.com').to_sql
+# => "SELECT * FROM contacts WHERE email='foo@bar.com'"
+```
+
+This feature is useful when you want to provide multiple intuitive ways for users to search the same field.
+
 ### Caveat
 
 If you search for a phrase containing a colon (e.g. `deploy:rollback`), Minidusen will mistake the first part as a – nonexistent – qualifier and return an empty set.

--- a/lib/minidusen/filter.rb
+++ b/lib/minidusen/filter.rb
@@ -6,8 +6,10 @@ module Minidusen
 
       attr_accessor :minidusen_syntax
 
-      def filter(field, &block)
-        minidusen_syntax.learn_field(field, &block)
+      def filter(*fields, &block)
+        fields.each do |field|
+          minidusen_syntax.learn_field(field, &block)
+        end
       end
 
     end

--- a/spec/minidusen/filter_spec.rb
+++ b/spec/minidusen/filter_spec.rb
@@ -224,4 +224,26 @@ describe Minidusen::Filter do
 
   end
 
+  describe 'filter aliases' do
+
+    it 'should support defining multiple field aliases with a single filter call' do
+      filter_class = Class.new do
+        include Minidusen::Filter
+
+        filter :name, :title do |scope, phrases|
+          scope.where_like([:name] => phrases)
+        end
+      end
+
+      filter_instance = filter_class.new
+
+      match = User.create!(:name => 'John Doe')
+      no_match = User.create!(:name => 'Jane Smith')
+
+      filter_instance.filter(User, 'name:John').to_a.should == [match]
+      filter_instance.filter(User, 'title:John').to_a.should == [match]
+    end
+
+  end
+
 end


### PR DESCRIPTION
Hi folks, we've been using minidusen in production at https://bardtracker.com for a while now, and so far its been a great fit for our search functionality. I'm opening this PR to inquire if there's an appetite to upstream the following filter alias functionality that we use extensively:

```ruby
filter :owner, :owner_id, :owned_by do |scope, string|
  ...
end
```

This is equivalent to duplicating the block three times, once for each field.

What do you think? If you're open to merging something like this, I'll make another pass to add tests and documentation. If not, cheers, and we'll just keep it as a monkey-patch.